### PR TITLE
Remove throwing error when there no dictionary for an identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Once you have your Swift package set up, adding Alamofire as a dependency is as 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/nimblehq/JSONMapper.git", .upToNextMajor(from: "1.0.1"))
+    .package(url: "https://github.com/nimblehq/JSONMapper.git", .upToNextMajor(from: "1.0.2"))
 ]
 ```
 

--- a/Sources/JSONMapper/JSONAPIDecoder.swift
+++ b/Sources/JSONMapper/JSONAPIDecoder.swift
@@ -129,7 +129,7 @@ extension JSONAPIDecoder {
     private func getResource(from includedDictionary: ResourceDictionary,
                              for identifier: ResourceIdentifier) throws -> Resource {
         guard let resource = includedDictionary[identifier] else {
-            throw Errors.JSONAPIDecodingError.resourceNotFound(identifier: identifier)
+            return Resource(id: identifier.id, type: identifier.type)
         }
         return resource
     }

--- a/Sources/JSONMapper/Models/Resource.swift
+++ b/Sources/JSONMapper/Models/Resource.swift
@@ -29,4 +29,13 @@ public struct Resource: JSONAPICodable {
         links = try container.decodeIfPresent(Links.self, forKey: .links)
         meta = try container.decodeIfPresent(JSON.self, forKey: .meta)
     }
+
+    init(id: String, type: String) {
+        self.id = id
+        self.type = type
+        self.attributes = nil
+        self.relationships = nil
+        self.links = nil
+        self.meta = nil
+    }
 }


### PR DESCRIPTION
## What happened 👀

In case the API returns with no dictionary data included, an exception will always be thrown. Example:

```
{
    "id": "some-id",
    "type": "some-type"
}
```
 
## Insight 📝

Accept the resource can have data for only id and type.