### PR TITLE
[#8] Fix: Unable to access JSONAPIError.source.paramater

### DIFF
--- a/Sources/JSONAPIMapper/Models/JSONAPIError.swift
+++ b/Sources/JSONAPIMapper/Models/JSONAPIError.swift
@@ -10,6 +10,10 @@ public struct JSONAPIError: Error, Decodable, Equatable {
 
     public struct Source: Decodable, Equatable {
         public let parameter: String?
+
+        public init(parameter: String? = nil) {
+            self.parameter = parameter
+        }
     }
     
     public let id: String?
@@ -20,6 +24,22 @@ public struct JSONAPIError: Error, Decodable, Equatable {
     public let status: String?
     /// application-specific error code
     public let code: String?
+
+    public init(
+        id: String? = nil,
+        title: String? = nil,
+        detail: String? = nil,
+        source: Source,
+        status: String? = nil,
+        code: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.source = source
+        self.status = status
+        self.code = code
+    }
 }
 
 /// JSON:API error object is sent as an array of errors.

--- a/Sources/JSONAPIMapper/Models/JSONAPIError.swift
+++ b/Sources/JSONAPIMapper/Models/JSONAPIError.swift
@@ -9,6 +9,7 @@ import Foundation
 public struct JSONAPIError: Error, Decodable, Equatable {
 
     public struct Source: Decodable, Equatable {
+
         public let parameter: String?
 
         public init(parameter: String? = nil) {

--- a/Sources/JSONAPIMapper/Models/JSONAPIError.swift
+++ b/Sources/JSONAPIMapper/Models/JSONAPIError.swift
@@ -29,7 +29,7 @@ public struct JSONAPIError: Error, Decodable, Equatable {
         id: String? = nil,
         title: String? = nil,
         detail: String? = nil,
-        source: Source,
+        source: Source? = nil,
         status: String? = nil,
         code: String? = nil
     ) {

--- a/Sources/JSONAPIMapper/Models/JSONAPIError.swift
+++ b/Sources/JSONAPIMapper/Models/JSONAPIError.swift
@@ -9,7 +9,7 @@ import Foundation
 public struct JSONAPIError: Error, Decodable, Equatable {
 
     public struct Source: Decodable, Equatable {
-        let parameter: String?
+        public let parameter: String?
     }
     
     public let id: String?


### PR DESCRIPTION
https://github.com/nimblehq/JSONMapper/issues/8

## What happened 👀

- Public `JSONAPIError.source.paramater`
- Add public constructors
 
## Insight 📝

n/a
 
## Proof Of Work 📹

Access `parameter` from outside without error
![Screen Shot 2022-05-10 at 10 30 41](https://user-images.githubusercontent.com/17875522/167537189-086398f4-da5a-4c35-8627-7276643b90ea.png)

